### PR TITLE
Use --remote for submodule update to get latest changes from wp-e2e-tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 checkout:
   post:
-    - git submodule update --init
+    - git submodule update --remote
 
 dependencies:
   cache_directories:


### PR DESCRIPTION
@hoverduck: do you want to 👀  this? I noticed using the original `submodule update --init` means you never get updates from the master branch of the wp-e2e-tests repo (have a look at the console output in CircleCI and it always has the same SHA). Using --remote seems to solve this problem to get the latest and still use submodules.
