### PR TITLE
Update node to 6.10.3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     NODE_ENV: test
   node:
-    version: 6.9.0
+    version: 6.10.3
   hosts:
     lorempixel.com: 127.0.0.1
     placekitten.com: 127.0.0.1


### PR DESCRIPTION
@hoverduck are there any issues with moving to 6.10.3 for the visdiff tests to match our main e2e tests?